### PR TITLE
Fix handling of public path

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -70,7 +70,7 @@ function buildExtension(options: IBuildOptions) {
     output: {
       path: path.join(process.cwd(), 'build'),
       filename: '[name].bundle.js',
-      publicPath: 'labextension/[name]'
+      publicPath: 'labextension/' + name
     },
     node: {
       fs: 'empty'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -104,12 +104,14 @@ class JupyterLabPlugin {
       manifest['files'] = chunk.files;
       manifest['modules'] = modules;
 
+      let manifestSource = JSON.stringify(manifest, null, '\t');
+
       compilation.assets[fileName + '.manifest'] = {
-        source: function() {
-          return JSON.stringify(manifest);
+        source: () => {
+          return manifestSource;
         },
-        size: function() {
-          return JSON.stringify(manifest).length;
+        size: () => {
+          return manifestSource.length;
         }
       };
 


### PR DESCRIPTION
With this change I was able to get a custom lab extension to build with the simple script:

``` javascript
var buildExtension = require('jupyterlab-extension-builder').buildExtension;

buildExtension({
  name: 'coolthing',
  entryPath: './index.js',
});
```
