### PR TITLE
Revamp the entry option and add an outputDir option to build configurations

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -51,7 +51,10 @@ function buildExtension(options: IBuildOptions) {
     throw Error('Must specify a name for the extension');
   }
   if (!options.entry) {
-    throw Error('Must specify an entryPath');
+    throw Error('Must specify an entry module');
+  }
+  if (!options.outputDir) {
+    throw Error('Must specify an output directory');
   }
 
   // Create the named entry point to the entryPath.
@@ -62,7 +65,7 @@ function buildExtension(options: IBuildOptions) {
     // The default options.
     entry: entry,
     output: {
-      path: path.resolve(options.outputDir || './build'),
+      path: path.resolve(options.outputDir),
       filename: '[name].bundle.js',
       publicPath: `labextension/${name}`
     },
@@ -138,12 +141,12 @@ interface IBuildOptions {
   entry: string;
 
   /**
-   * The directory in which to put the bundled files.
+   * The directory in which to put the generated bundle files.
    *
    * Relative directories are resolved relative to the current
-   * working directory of the process. The default is './build'.
+   * working directory of the process.
    */
-  outputDir?: string;
+  outputDir: string;
 
   /**
    * Whether to extract CSS from the bundles (default is True).

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -46,29 +46,23 @@ DEFAULT_LOADERS = [
 export
 function buildExtension(options: IBuildOptions) {
   let name = options.name;
-  let entryPath = options.entryPath;
 
   if (!name) {
     throw Error('Must specify a name for the extension');
   }
-  if (!entryPath) {
+  if (!options.entry) {
     throw Error('Must specify an entryPath');
-  }
-  try {
-    fs.statSync(path.join(process.cwd(), entryPath));
-  } catch (e) {
-    throw Error(`Invalid path to entry point: ${entryPath}`);
   }
 
   // Create the named entry point to the entryPath.
   let entry: { [key: string]: string } = {};
-  entry[name] = options.entryPath;
+  entry[name] = options.entry;
 
   let config = new Config().merge({
     // The default options.
     entry: entry,
     output: {
-      path: path.join(process.cwd(), 'build'),
+      path: path.resolve(options.outputDir || './build'),
       filename: '[name].bundle.js',
       publicPath: `labextension/${name}`
     },
@@ -136,9 +130,20 @@ interface IBuildOptions {
   name: string;
 
   /**
-   * The path to the entry point.
+   * The module to load as the entry point.
+   *
+   * The module should export a plugin configuration or array of
+   * plugin configurations.
    */
-  entryPath: string;
+  entry: string;
+
+  /**
+   * The directory in which to put the bundled files.
+   *
+   * Relative directories are resolved relative to the current
+   * working directory of the process. The default is './build'.
+   */
+  outputDir?: string;
 
   /**
    * Whether to extract CSS from the bundles (default is True).


### PR DESCRIPTION
The entry option should be a module, not necessarily a path, so we clarify the name.

We also often need to specify the output directory, so we abstract over the webpack config for the user.

TODO:
- [x] Testing
