### PR TITLE
Make the loader understand custom loaders.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -363,7 +363,7 @@ namespace Private {
   }
 
   /**
-   * Get a mangled path for a path using the extact version.
+   * Get a mangled path for a path using the exact version.
    *
    * @param path - The absolute path of the module.
    *


### PR DESCRIPTION
Similar to how we build the version strings, when we load a module with !-separated loaders, we compare each version separately, in reverse order so the base file has the most important version comparison.
