### PR TITLE
Use the private source api

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -134,7 +134,7 @@ class JupyterLabPlugin {
     let pluginName = this._name;
     let publicPath = this._publicPath;
     let requireName = `__${pluginName}_require__`;
-    let source = mod.source().source();
+    let source = mod._source().source();
 
     // Regular modules.
     if (mod.userRequest) {


### PR DESCRIPTION
Fixes #5.  This API is used by WebPack itself in the `Stats` [module](https://github.com/webpack/webpack/blob/ac340bce1d7239c0e6c0d0cf93dbb6c26dddde1f/lib/Stats.js#L266).  We don't have all the required arguments for the `source()` [function](https://github.com/webpack/webpack/blob/a53799c0ac58983860a27648cdc8519b6a562b89/lib/NormalModule.js#L224).
