### PR TITLE
Separate the validate function and do not use from node

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -54,8 +54,6 @@ function buildExtension(options: IBuildOptions) {
     throw Error('Must specify an output directory');
   }
 
-  validateEntry(require(options.entry));
-
   // Create the named entry point to the entryPath.
   let entry: { [key: string]: string } = {};
   entry[name] = options.entry;
@@ -165,34 +163,4 @@ interface IBuildOptions {
    * Extra webpack configuration.
    */
   config?: webpack.Configuration;
-}
-
-
-/**
- * Validate the entry point of a JupyterLab extension.
- *
- * @param data - The loaded entry point module.
- */
-export
-function validateEntry(data: any): void {
-  // We use the default export from es6 modules.
-  if (data.__esModule) {
-    data = data.default;
-  }
-  if (!Array.isArray(data)) {
-    data = [data];
-  }
-  if (!data.length) {
-    throw new Error(`No plugins found`);
-  }
-  for (let i = 0; i < data.length; i++) {
-    let plugin = data[i];
-    if (!plugin.hasOwnProperty('id')) {
-      throw new Error(`Missing id for plugin ${i}`);
-    }
-    if (typeof(plugin['activate']) !== 'function') {
-      let id: string = plugin.id;
-      throw Error(`Missing activate function in '${id}'`);
-    }
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@
 
 export * from './builder';
 export * from './plugin';
+export * from './validate';

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+
+/**
+ * Validate the entry point of a JupyterLab extension.
+ *
+ * @param data - The loaded entry point module.
+ */
+export
+function validateEntry(data: any): void {
+  // We use the default export from es6 modules.
+  if (data.__esModule) {
+    data = data.default;
+  }
+  if (!Array.isArray(data)) {
+    data = [data];
+  }
+  if (!data.length) {
+    throw new Error(`No plugins found`);
+  }
+  for (let i = 0; i < data.length; i++) {
+    let plugin = data[i];
+    if (!plugin.hasOwnProperty('id')) {
+      throw new Error(`Missing id for plugin ${i}`);
+    }
+    if (typeof(plugin['activate']) !== 'function') {
+      let id: string = plugin.id;
+      throw Error(`Missing activate function in '${id}'`);
+    }
+  }
+}

--- a/test/src/builder.spec.ts
+++ b/test/src/builder.spec.ts
@@ -4,53 +4,13 @@
 import expect = require('expect.js');
 
 import {
-  buildExtension, validateEntry
+  buildExtension
 } from '../../lib';
 
 
 describe('builder', () => {
 
-  describe('validateEntry()', () => {
-
-    it('should pass for a valid plugin array', () => {
-      validateEntry([{
-        id: 'foo',
-        activate: () => { /* no-op */ }
-      }, {
-        id: 'bar',
-        activate: () => { /* no-op */ }
-      }]);
-    });
-
-    it('should pass for a valid plugin', () => {
-      validateEntry({
-        id: 'foo',
-        activate: () => { /* no-op */ }
-      });
-    });
-
-    it('should pass for an ES6 default', () => {
-      validateEntry({
-        __esModule: true,
-        default: {
-          id: 'foo',
-          activate: () => { /* no-op */ }
-        }
-      });
-    });
-
-    it('should fail if it is an empty array', () => {
-      expect(() => { validateEntry([]); }).to.throwError();
-    });
-
-    it('should fail if a plugin is missing an id', () => {
-      let activate: () => { /* no-op */ };
-      expect(() => { validateEntry({ activate }); }).to.throwError();
-    });
-
-    it('should fail if a plugin is missing an activate function', () => {
-      expect(() => { validateEntry({ id: 'foo' }); }).to.throwError();
-    });
+  it('should pass', () => {
 
   });
 

--- a/test/src/validate.spec.ts
+++ b/test/src/validate.spec.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  validateEntry
+} from '../../lib';
+
+
+describe('validate', () => {
+
+  describe('validateEntry()', () => {
+
+    it('should pass for a valid plugin array', () => {
+      validateEntry([{
+        id: 'foo',
+        activate: () => { /* no-op */ }
+      }, {
+        id: 'bar',
+        activate: () => { /* no-op */ }
+      }]);
+    });
+
+    it('should pass for a valid plugin', () => {
+      validateEntry({
+        id: 'foo',
+        activate: () => { /* no-op */ }
+      });
+    });
+
+    it('should pass for an ES6 default', () => {
+      validateEntry({
+        __esModule: true,
+        default: {
+          id: 'foo',
+          activate: () => { /* no-op */ }
+        }
+      });
+    });
+
+    it('should fail if it is an empty array', () => {
+      expect(() => { validateEntry([]); }).to.throwError();
+    });
+
+    it('should fail if a plugin is missing an id', () => {
+      let activate: () => { /* no-op */ };
+      expect(() => { validateEntry({ activate }); }).to.throwError();
+    });
+
+    it('should fail if a plugin is missing an activate function', () => {
+      expect(() => { validateEntry({ id: 'foo' }); }).to.throwError();
+    });
+
+  });
+
+});


### PR DESCRIPTION
We cannot `require()` an entry point from node because it may contain browser-specific logic, for example `window.navigator`.
