### PR TITLE
Force the validate function to be separate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,3 @@
 
 export * from './builder';
 export * from './plugin';
-export * from './validate';

--- a/test/src/validate.spec.ts
+++ b/test/src/validate.spec.ts
@@ -5,7 +5,7 @@ import expect = require('expect.js');
 
 import {
   validateEntry
-} from '../../lib';
+} from '../../lib/validate';
 
 
 describe('validate', () => {


### PR DESCRIPTION
We can't WebPack the builder script, so we need to keep the browser code separate.
