### PR TITLE
Use the same error handling output as webpack itself

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -106,8 +106,8 @@ function buildExtension(options: IBuildOptions) {
   compiler.run((err, stats) => {
     if (err) {
       console.error(err.stack || err);
-      if (err.details) {
-        console.error(err.details);
+      if ((err as any).details) {
+        console.error((err as any).details);
       }
     } else {
       console.log(`\n\nSuccessfully built "${name}":\n`);

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -105,7 +105,10 @@ function buildExtension(options: IBuildOptions) {
   compiler.context = name;
   compiler.run((err, stats) => {
     if (err) {
-      console.error(err.message);
+      console.error(err.stack || err);
+      if (err.details) {
+        console.error(err.details);
+      }
     } else {
       console.log(`\n\nSuccessfully built "${name}":\n`);
       process.stdout.write(stats.toString({


### PR DESCRIPTION
Fixes #29.

Follows conventions from the `webpack` [cli](https://github.com/webpack/webpack/blob/18929db92ab3176735447f0059982ed6200317b7/bin/webpack.js#L300).
