### PR TITLE
Fix the public path handling

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -174,8 +174,8 @@ class JupyterLabPlugin {
     }
 
     // Handle public requires.
-    let requireP = '__webpack_require__.p';
-    let newRequireP = `'${publicPath}'`;
+    let requireP = '__webpack_require__.p +';
+    let newRequireP = `'${publicPath}' +`;
     source = source.split(requireP).join(newRequireP);
 
     // Replace the require name with the custom one.


### PR DESCRIPTION
@gnestor, with this change I was able to get https://github.com/gnestor/jupyterlab_table/tree/labextension-build to limp along to this point:

![image](https://cloud.githubusercontent.com/assets/2096628/20820452/e196816a-b800-11e6-86a3-5b5e1e3066f6.png)


I had to `npm install -g css-loader` and change `application/table-schema+json` -> `application/json`.  