### PR TITLE
Use the file loader for source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@types/webpack": "^1.12.35",
+    "@types/lodash": "ts2.0",
     "css-loader": "^0.25.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -27,6 +27,7 @@ DEFAULT_LOADERS = [
   { test: /\.json$/, loader: 'json-loader' },
   { test: /\.html$/, loader: 'file-loader' },
   { test: /\.(jpg|png|gif)$/, loader: 'file-loader' },
+  { test: /\.js.map$/, loader: 'file-loader' },
   { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
   { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
   { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/octet-stream' },


### PR DESCRIPTION
There are included in xterm 2.2 and cause parsing errors.